### PR TITLE
Csharpify this lib

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+# All files
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+[*.{cs}]
+csharp_new_line_before_open_brace = all

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,5 +5,134 @@ root = true
 indent_style = space
 indent_size = 4
 end_of_line = lf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 [*.{cs}]
 csharp_new_line_before_open_brace = all
+
+[*.cs]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_indent_labels = no_change
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_else = true
+
+[*.vb]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, friend, private, protected, protected_friend, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, friend, private, protected, protected_friend, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, friend, private, protected, protected_friend, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case

--- a/WebUI.NET.sln
+++ b/WebUI.NET.sln
@@ -1,42 +1,45 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A18A8D0B-6550-4C02-80D8-4D8DCC8A4C26}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebUI.NET", "src\WebUI.NET\WebUI.NET.csproj", "{473FADD0-6CEF-4832-9ABC-8370A8539292}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebUI.NET", "src\WebUI.NET\WebUI.NET.csproj", "{473FADD0-6CEF-4832-9ABC-8370A8539292}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebUI.NET.Natives", "src\WebUI.NET.Natives\WebUI.NET.Natives.csproj", "{BE09800A-7B7D-44F4-A294-372BBD5C9B9D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebUI.NET.Natives", "src\WebUI.NET.Natives\WebUI.NET.Natives.csproj", "{BE09800A-7B7D-44F4-A294-372BBD5C9B9D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebUI.NET.Natives.Secure", "src\WebUI.NET.Natives.Secure\WebUI.NET.Natives.Secure.csproj", "{444F629E-4AFF-4454-A1B2-4F765810321C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebUI.NET.Natives.Secure", "src\WebUI.NET.Natives.Secure\WebUI.NET.Natives.Secure.csproj", "{444F629E-4AFF-4454-A1B2-4F765810321C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{646E5093-39B6-4C21-8EEE-1488488F2366}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "basic_window", "examples\basic_window\basic_window.csproj", "{9BA583A6-1986-402E-BC29-5E054F6224E8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "basic_window", "examples\basic_window\basic_window.csproj", "{9BA583A6-1986-402E-BC29-5E054F6224E8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "basic_window_net48", "examples\basic_window_net48\basic_window_net48.csproj", "{B04F7684-A967-4977-901A-17A336AF02EF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "basic_window_net48", "examples\basic_window_net48\basic_window_net48.csproj", "{B04F7684-A967-4977-901A-17A336AF02EF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "events", "examples\events\events.csproj", "{BE2C15B8-EEB9-46E3-BA90-06432CD1C9D5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "events", "examples\events\events.csproj", "{BE2C15B8-EEB9-46E3-BA90-06432CD1C9D5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dynamic_content", "examples\dynamic_content\dynamic_content.csproj", "{A1B64637-4976-41AA-8F56-1D7E58DED082}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dynamic_content", "examples\dynamic_content\dynamic_content.csproj", "{A1B64637-4976-41AA-8F56-1D7E58DED082}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "js_interop", "examples\js_interop\js_interop.csproj", "{6543E52E-FB68-4754-848A-24E9927CC258}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "js_interop", "examples\js_interop\js_interop.csproj", "{6543E52E-FB68-4754-848A-24E9927CC258}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "js_call", "examples\js_call\js_call.csproj", "{085C4587-AB5B-4ECC-9CD8-E8C3D9ED0F2B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "js_call", "examples\js_call\js_call.csproj", "{085C4587-AB5B-4ECC-9CD8-E8C3D9ED0F2B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "invoke_backend_function", "examples\invoke_backend_function\invoke_backend_function.csproj", "{BF7D75E8-B257-45AD-9DB6-439DA9AB927C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "invoke_backend_function", "examples\invoke_backend_function\invoke_backend_function.csproj", "{BF7D75E8-B257-45AD-9DB6-439DA9AB927C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "text_editor", "examples\text_editor\text_editor.csproj", "{047D6121-AF91-4428-8B92-C31A976E5642}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "text_editor", "examples\text_editor\text_editor.csproj", "{047D6121-AF91-4428-8B92-C31A976E5642}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "native_api", "examples\native_api\native_api.csproj", "{7662158E-8A4E-4904-9656-69B1E2064D06}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "native_api", "examples\native_api\native_api.csproj", "{7662158E-8A4E-4904-9656-69B1E2064D06}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{350DEBCA-D462-4937-A562-D3939B9CEC35}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{473FADD0-6CEF-4832-9ABC-8370A8539292}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -87,6 +90,13 @@ Global
 		{7662158E-8A4E-4904-9656-69B1E2064D06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7662158E-8A4E-4904-9656-69B1E2064D06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7662158E-8A4E-4904-9656-69B1E2064D06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6391CD02-5B36-48C0-968F-F9C95ACD5A54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6391CD02-5B36-48C0-968F-F9C95ACD5A54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6391CD02-5B36-48C0-968F-F9C95ACD5A54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6391CD02-5B36-48C0-968F-F9C95ACD5A54}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{473FADD0-6CEF-4832-9ABC-8370A8539292} = {A18A8D0B-6550-4C02-80D8-4D8DCC8A4C26}
@@ -101,5 +111,6 @@ Global
 		{BF7D75E8-B257-45AD-9DB6-439DA9AB927C} = {646E5093-39B6-4C21-8EEE-1488488F2366}
 		{047D6121-AF91-4428-8B92-C31A976E5642} = {646E5093-39B6-4C21-8EEE-1488488F2366}
 		{7662158E-8A4E-4904-9656-69B1E2064D06} = {646E5093-39B6-4C21-8EEE-1488488F2366}
+		{6391CD02-5B36-48C0-968F-F9C95ACD5A54} = {646E5093-39B6-4C21-8EEE-1488488F2366}
 	EndGlobalSection
 EndGlobal

--- a/WebUI.NET.sln
+++ b/WebUI.NET.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfControllerApp", "examples\WpfControllerApp\WpfControllerApp.csproj", "{6391CD02-5B36-48C0-968F-F9C95ACD5A54}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/examples/WpfControllerApp/App.xaml
+++ b/examples/WpfControllerApp/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="WpfControllerApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:WpfControllerApp"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/examples/WpfControllerApp/App.xaml.cs
+++ b/examples/WpfControllerApp/App.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace WpfControllerApp {
+	/// <summary>
+	/// Interaction logic for App.xaml
+	/// </summary>
+	public partial class App : Application {
+	}
+
+}

--- a/examples/WpfControllerApp/AssemblyInfo.cs
+++ b/examples/WpfControllerApp/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly: ThemeInfo(
+	ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+												//(used if a resource is not found in the page,
+												// or application resource dictionaries)
+	ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+												//(used if a resource is not found in the page,
+												// app, or any theme specific resource dictionaries)
+)]

--- a/examples/WpfControllerApp/MainWindow.xaml
+++ b/examples/WpfControllerApp/MainWindow.xaml
@@ -1,0 +1,20 @@
+<Window x:Class="WpfControllerApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:WpfControllerApp"
+        mc:Ignorable="d"
+        Title="MainWindow" Height="450" Width="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+		<StackPanel Orientation="Horizontal" Margin="5" VerticalAlignment="Center" HorizontalAlignment="Center" >
+			<Button Content="c# => Javascript Tests" Click="btnTest1_Click" Margin="5" />
+            <Button Content="Toggle Dev Tools" Click="btnDevTools_Click" Margin="5" />
+        </StackPanel>
+        <TextBox IsReadOnly="True" Grid.Row="1" Margin="5" Name="txtLog" />
+    </Grid>
+</Window>

--- a/examples/WpfControllerApp/MainWindow.xaml.cs
+++ b/examples/WpfControllerApp/MainWindow.xaml.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Threading;
+using WebUI;
+using Windows.Win32;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
+
+namespace WpfControllerApp
+{
+    /// <summary>
+    /// Interaction logic for MainWindow.xaml
+    /// </summary>
+    public partial class MainWindow : System.Windows.Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+            Loaded += MainWindow_Loaded;
+            Closing += MainWindow_Closing;
+        }
+
+        private void MainWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            window?.Close();
+        }
+
+        WebUI.Window window;
+        public class WinDispatcher : WebUI.Window.IInvokerHelper
+        {
+            private Dispatcher dispatcher;
+            public WinDispatcher(Dispatcher dispatcher)
+            {
+                this.dispatcher = dispatcher;
+            }
+            public T InvokeWithReturnType<T>(Func<T> action) => dispatcher.Invoke<T>(action);
+
+            public void InvokeWithVoid(Action action) => dispatcher.Invoke(action);
+        }
+        private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            WebUI.Window.UseSpecificDispatcher = new WinDispatcher(Dispatcher);
+
+            window = new(new WebUI.WindowProperties { Width = 640, Height = 480, X = 800, Y = 50 });
+            var evts = window.RegisterDefaultEventHandler();
+            evts.OnDisconnect += (_) =>
+            {
+                window = null;
+                Dispatcher.InvokeAsync(() => Close());
+            };
+            window.Show("index.html");
+
+            window.RegisterOnClick(JSClickedButton, "TestButton");
+            window.RegisterBoundFunction(() => MyTest_function);
+        }
+        private async Task<string> MyTest_function(String arg1, String arg2, double arg3)
+        {
+            var str = $"I am called: {arg1}({arg1.GetType()}) and {arg2}({arg2.GetType()}) {arg3}({arg3.GetType()})";
+            LogItem(str);
+            await Task.Delay(500);
+            return "Nice Call " + arg1;
+        }
+        private void JSClickedButton(String elem)
+        {
+            LogItem($"Got a click from JS for: {elem}");
+        }
+
+        private void LogItem(object val, [CallerArgumentExpression(nameof(val))] string expression = "unknown")
+        {
+            var valStr = val switch
+            {
+                String[] sarr => String.Join(", ", sarr),
+                double or decimal or float or char or bool or int or string => val.ToString(),
+                _ => "Serialized as: " + Newtonsoft.Json.JsonConvert.SerializeObject(val, Newtonsoft.Json.Formatting.None)
+            };
+            txtLog.Text += $"{expression} => {valStr} ({val.GetType()})\n";
+        }
+        private async void btnTest1_Click(object sender, RoutedEventArgs e)
+        {
+            LogItem(await window.ScriptEvaluate<double>("return 5.143123;"));
+            LogItem(await window.ScriptEvaluate<double>("return getDouble();"));
+            LogItem(await window.ScriptEvaluate<String>("return getStrWArgs('arg1','arg2');"));
+            LogItem(await window.ScriptEvaluateMethod<String>("getStrWArgs", "arg1", 1234.5678));
+            LogItem(await window.ScriptEvaluateMethod<String[]>("getStrArr"));
+            LogItem(await window.ScriptEvaluateMethod<ComplexObj>("getComplexObj"));
+        }
+        public class ComplexObj
+        {
+            public int id;
+            public class ComplexObjSub
+            {
+                public string name;
+                public string val;
+            }
+            public ComplexObjSub subObj;
+            public object[] subArr;
+        }
+        private async void SendF12()
+        {
+            var mainWindHandle = window.GetBrowserChildProcess().MainWindowHandle;//main process null?
+            PInvoke.SetForegroundWindow(new(mainWindHandle));
+            PInvoke.PostMessage(new(mainWindHandle), PInvoke.WM_KEYDOWN, new Windows.Win32.Foundation.WPARAM((nuint)VIRTUAL_KEY.VK_F12), default);
+            await Task.Delay(50);
+            PInvoke.PostMessage(new(mainWindHandle), PInvoke.WM_KEYUP, new Windows.Win32.Foundation.WPARAM((nuint)VIRTUAL_KEY.VK_F12), default);
+        }
+
+        private void btnDevTools_Click(object sender, RoutedEventArgs e)
+        {
+            SendF12();
+        }
+    }
+}

--- a/examples/WpfControllerApp/NativeMethods.txt
+++ b/examples/WpfControllerApp/NativeMethods.txt
@@ -1,0 +1,7 @@
+PostMessage
+VIRTUAL_KEY
+WM_KEYDOWN
+WM_KEYUP
+SendInput
+INPUT
+SetForegroundWindow

--- a/examples/WpfControllerApp/WpfControllerApp.csproj
+++ b/examples/WpfControllerApp/WpfControllerApp.csproj
@@ -1,0 +1,50 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WebUI.NET\WebUI.NET.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="index.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+    <Choose>
+        <When Condition="'$(Configuration)' == 'Debug'">
+            <ItemGroup>
+                <PackageReference Include="WebUI.NET.Natives" Version="*-*" />
+            </ItemGroup>
+            <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <RestoreAdditionalProjectSources>
+                    $(MSBuildThisFileDirectory)/../../nupkg/Debug/
+                </RestoreAdditionalProjectSources>
+            </PropertyGroup>
+        </When>
+    </Choose>
+    <Choose>
+        <When Condition="'$(Configuration)' == 'Release'">
+            <ItemGroup>
+                <PackageReference Include="WebUI.NET.Natives" Version="*-*" />
+            </ItemGroup>
+            <PropertyGroup>
+                <OutputType>WinExe</OutputType>
+                <RestoreAdditionalProjectSources>
+                    $(MSBuildThisFileDirectory)/../../nupkg/Release/
+                </RestoreAdditionalProjectSources>
+            </PropertyGroup>
+        </When>
+    </Choose>
+</Project>

--- a/examples/WpfControllerApp/index.html
+++ b/examples/WpfControllerApp/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta charset="utf-8" />
+	<script src="webui.js"></script>
+	<title>JS Interop</title>
+	<script>
+
+		const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+		async function SampleAsync() {
+			const startTime = performance.now();
+			await delay(750);
+			return `Async Delayed for: ${performance.now() - startTime}ms`;
+		}
+		const getStrWArgs = (...args) => `You passed us: ${Array.from(args).join(", ")}`;
+
+		const getDouble = () => Math.random() * 1234;
+
+
+		const getStrArr = () => "My string array".split(" ");
+
+		const complexObj = { "id": 123, subObj: { name: "bob", val: "of course" }, subArr: ["lots", "of", 123.4] };
+		const getComplexObj = () => complexObj;
+
+		async function btn2Clicked() {
+			let res = await webui.call("MyTest_function", "an", "arg", 12345.78);
+			alert("You returned: " + res);
+		}
+
+		//generate();
+	</script>
+</head>
+<body>
+	<button id="TestButton">Javascript => C# Tests</button>
+	<button id="TestButton2" onclick="btn2Clicked()">Click ME2!</button>
+</body>
+</html>

--- a/examples/WpfControllerApp/index.html
+++ b/examples/WpfControllerApp/index.html
@@ -4,6 +4,7 @@
 <head>
 	<meta charset="utf-8" />
 	<script src="webui.js"></script>
+	<script src="webui_net.js"></script>
 	<title>JS Interop</title>
 	<script>
 
@@ -25,7 +26,7 @@
 		const getComplexObj = () => complexObj;
 
 		async function btn2Clicked() {
-			let res = await webui.call("MyTest_function", "an", "arg", 12345.78);
+				let res = await MyTest_function("1st JS Arg Passed to C#", "arg", 12345.78);
 			alert("You returned: " + res);
 		}
 

--- a/src/WebUI.NET/Events/Event.cs
+++ b/src/WebUI.NET/Events/Event.cs
@@ -162,7 +162,7 @@ namespace WebUI.Events
         }
 
 #if NET7_0_OR_GREATER
-        private static partial class Natives
+        internal static partial class Natives
         {
             [LibraryImport(Utils.LibraryName, StringMarshalling = StringMarshalling.Utf8, EntryPoint = "webui_interface_get_int_at")]
             [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
@@ -187,7 +187,7 @@ namespace WebUI.Events
             public static partial void WebUIReturn(IntPtr windowHandle, UIntPtr eventId, string content);
         }
 #else
-        private static class Natives
+        internal static class Natives
         {
             [DllImport(Utils.LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi,
                 ThrowOnUnmappableChar = false, BestFitMapping = false,

--- a/src/WebUI.NET/MilisecondEpochConverter.cs
+++ b/src/WebUI.NET/MilisecondEpochConverter.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace WebUI
+{
+    public class MilisecondEpochConverter : RandomNumberTimeConverter<long, DateTime>
+    {
+        private static readonly DateTime _epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public MilisecondEpochConverter() : base(long.Parse) { }
+
+        public static DateTime ParseLong(long val) => _epoch.AddMilliseconds(val);
+
+        protected override DateTime ParseValue(long val) => ParseLong(val);
+
+        protected override string WriteValue(DateTime when)
+        {
+            return ((long)(when - _epoch).TotalMilliseconds).ToString();
+        }
+        public override bool CanConvert(Type objectType)
+        {
+            if (objectType == typeof(DateTime) || objectType == typeof(DateTime?))
+            {
+                return true;
+            }
+
+            if (objectType == typeof(DateTimeOffset) || objectType == typeof(DateTimeOffset?))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+    public abstract class RandomNumberTimeConverter<T, SOURCE_TYPE> : JsonConverter
+    {
+        protected RandomNumberTimeConverter(Func<String, T> ParseNotNullStringHandler)
+        {
+            this.ParseNotNullStringHandler = ParseNotNullStringHandler;
+        }
+        Func<String, T> ParseNotNullStringHandler;
+
+        protected abstract SOURCE_TYPE ParseValue(T val);
+        protected abstract String WriteValue(SOURCE_TYPE when);
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteRawValue(WriteValue((SOURCE_TYPE)value));
+
+
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Value == null) { return null; }
+            T val;
+            if (reader.TokenType == JsonToken.String)
+                val = ParseNotNullStringHandler((string)reader.Value);
+            else
+                val = (T)Convert.ChangeType(reader.Value, typeof(T));
+            return ParseValue(val);
+        }
+    }
+}

--- a/src/WebUI.NET/Models/CEFSharpImports.cs
+++ b/src/WebUI.NET/Models/CEFSharpImports.cs
@@ -1,0 +1,136 @@
+﻿/*
+This code is generally taken directly from or modified from the fantastic CefSharp project (https://github.com/cefsharp/CefSharp) please support: https://github.com/sponsors/amaitland the license:
+
+// Copyright © The CefSharp Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above
+//      copyright notice, this list of conditions and the following disclaimer
+//      in the documentation and/or other materials provided with the
+//      distribution.
+//
+//    * Neither the name of Google Inc. nor the name Chromium Embedded
+//      Framework nor the name CefSharp nor the names of its contributors
+//      may be used to endorse or promote products derived from this software
+//      without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace WebUI.Models
+{
+    public static class CEFSharpImports
+    {
+        /*https://raw.githubusercontent.com/cefsharp/CefSharp/master/CefSharp/WebBrowserExtensions.cs*/
+             /// <summary>
+        /// Function used to encode the params passed to <see cref="ExecuteScriptAsync(IWebBrowser, string, object[])"/>,
+        /// <see cref="EvaluateScriptAsync(IWebBrowser, string, object[])"/> and
+        /// <see cref="EvaluateScriptAsync(IWebBrowser, TimeSpan?, string, object[])"/>
+        /// Provide your own custom function to perform custom encoding. You can use your choice of JSON encoder here if you should so
+        /// choose.
+        /// </summary>
+        /// <value>
+        /// A function delegate that yields a string.
+        /// </value>
+        public static Func<string, string> EncodeScriptParam { get; set; } = (str) =>
+        {
+            return str.Replace("\\", "\\\\")
+                .Replace("'", "\\'")
+                .Replace("\t", "\\t")
+                .Replace("\r", "\\r")
+                .Replace("\n", "\\n");
+        };
+         /// <summary>
+        /// Checks if the given object is a numerical object.
+        /// </summary>
+        /// <param name="value">The object to check.</param>
+        /// <returns>
+        /// True if numeric, otherwise false.
+        /// </returns>
+        private static bool IsNumeric(this object value)
+        {
+            return value is sbyte
+                    || value is byte
+                    || value is short
+                    || value is ushort
+                    || value is int
+                    || value is uint
+                    || value is long
+                    || value is ulong
+                    || value is float
+                    || value is double
+                    || value is decimal;
+        }
+         /// <summary>
+        /// Transforms the methodName and arguments into valid Javascript code. Will encapsulate params in single quotes (unless int,
+        /// uint, etc)
+        /// </summary>
+        /// <param name="methodName">The javascript method name to execute.</param>
+        /// <param name="args">the arguments to be passed as params to the method.</param>
+        /// <returns>
+        /// The Javascript code.
+        /// </returns>
+        public static string GetScriptForJavascriptMethodWithArgs(string methodName, object[] args)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.Append(methodName);
+            stringBuilder.Append("(");
+
+            if (args.Length > 0)
+            {
+                for (int i = 0; i < args.Length; i++)
+                {
+                    var obj = args[i];
+                    if (obj == null)
+                    {
+                        stringBuilder.Append("null");
+                    }
+                    else if (obj.IsNumeric())
+                    {
+                        stringBuilder.Append(Convert.ToString(args[i], CultureInfo.InvariantCulture));
+                    }
+                    else if (obj is bool)
+                    {
+                        stringBuilder.Append(args[i].ToString().ToLowerInvariant());
+                    }
+                    else
+                    {
+                        stringBuilder.Append("'");
+                        stringBuilder.Append(EncodeScriptParam(obj.ToString()));
+                        stringBuilder.Append("'");
+                    }
+
+                    stringBuilder.Append(", ");
+                }
+
+                //Remove the trailing comma
+                stringBuilder.Remove(stringBuilder.Length - 2, 2);
+            }
+
+            stringBuilder.Append(")");
+
+            return stringBuilder.ToString();
+        }
+    }
+}

--- a/src/WebUI.NET/Models/ReflectionHelpers.cs
+++ b/src/WebUI.NET/Models/ReflectionHelpers.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+
+namespace WebUI.Models
+{
+    public static class ReflectionHelpers
+    {
+        /// <summary>Given a lambda expression that calls a method, returns the method info</summary>
+		/// <param name="expression">The lambda expression using the method</param>
+		/// <returns>The method in the lambda expression</returns>
+		///
+		public static MethodInfo GetMethodInfo(LambdaExpression expression, out object instance)
+        {
+            instance = null;
+            var outermostExpression = expression.Body as MethodCallExpression;
+            if (outermostExpression != null)
+            {
+                Expression<Func<Object>> getCallerExpression = Expression<Func<Object>>.Lambda<Func<Object>>(outermostExpression.Object);
+                instance = getCallerExpression.Compile()();//need to verify this working
+
+            }
+            if (outermostExpression is null)
+            {
+                if (expression.Body is UnaryExpression ue && ue.Operand is MethodCallExpression me && me.Object is System.Linq.Expressions.ConstantExpression ce && ce.Value is MethodInfo mi)
+                {
+                    if (me.Arguments.Count > 1)
+                    {
+                        var inst = me.Arguments.ElementAt(1);
+                        if (inst is ConstantExpression ce2)
+                            instance = ce2.Value;
+
+                    }
+                    return mi;
+                }
+                throw new ArgumentException("Invalid Expression. Expression should consist of a Method call only.");
+            }
+
+            var method = outermostExpression.Method;
+            if (method is null)
+                throw new Exception($"Cannot find method for expression {expression}");
+
+            return method;
+        }
+
+        public static (object[] defaultVals, Type[] argTypes) GetArgsForMethod(MethodInfo method)
+        {
+            var infoArgs = method.GetParameters();
+            var defaultCallArgs = new object[infoArgs.Length];
+            var callArgTypes = infoArgs.Select(a => a.ParameterType).ToArray();
+            for (var x = 0; x < infoArgs.Length; x++)
+            {
+                var infoArg = infoArgs[x];
+                if (infoArg.HasDefaultValue)
+                    defaultCallArgs[x] = infoArg.DefaultValue;
+                else
+                {
+                    if (!infoArg.ParameterType.IsValueType)
+                        defaultCallArgs[x] = null;
+                    else
+                        defaultCallArgs[x] = Activator.CreateInstance(infoArg.ParameterType);
+                }
+            }
+            return (defaultCallArgs, callArgTypes);
+        }
+    }
+}

--- a/src/WebUI.NET/WebUI.NET.csproj
+++ b/src/WebUI.NET/WebUI.NET.csproj
@@ -13,7 +13,7 @@
 		<Nullable>disable</Nullable>
 		<WarningLevel>9999</WarningLevel>
 		<RootNamespace>WebUI</RootNamespace>
-
+        <LangVersion>preview</LangVersion>
 		<IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
 	</PropertyGroup>
 	<PropertyGroup>
@@ -59,7 +59,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 
 </Project>

--- a/src/WebUI.NET/WebUI.NET.csproj
+++ b/src/WebUI.NET/WebUI.NET.csproj
@@ -64,4 +64,10 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <None Update="webui_net.js">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+
 </Project>

--- a/src/WebUI.NET/WebUINetUI.cs
+++ b/src/WebUI.NET/WebUINetUI.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace WebUI
+{
+   
+    public class DomEvent
+    {
+
+        public string currentTargetId { get; set; }
+        public string originalTargetId { get; set; }
+        [JsonConverter(typeof(MilisecondEpochConverter))]
+        public DateTime timestamp { get; set; }
+        public string type { get; set; }
+        public Dictionary<string, string> additionalProps; //map of additional property values requested
+
+    }
+    public enum CommonEventTypes { load, unload, error, resize, scroll, focus, blur, click, dblclick, mousedown, mouseup, mouseover, mouseout, mousemove, input, keydown, keypress, keyup, submit, change, DOMNodeInserted, DOMNodeRemoved, DOMSubtreeModified, DOMNodeInsertedIntoDocument, DOMNodeRemovedFromDocument, DOMContentLoaded, hashchange, beforeunload }
+    public static class WebUINetUI
+    {
+
+        public class EventOpts
+        {
+            public bool capture { get; set; }
+            public bool once { get; set; }
+            public string abortKey { get; set; }
+
+        }
+        private const int startId = 5432;
+        private static volatile int curFuncId = startId;
+        // CommonEventTypes
+        public static void AddEventListener(this Window window, Action<DomEvent> OnFired, CommonEventTypes eventType, String domId, EventOpts additionalOpts = null, params KeyValuePair<string, string>[] additionalEventCaptureProps) => window.AddEventListener(OnFired, eventType.ToString(), domId, additionalOpts, additionalEventCaptureProps);
+
+        public static void AddEventListener(this Window window, Action<DomEvent> OnFired, String eventType, String domId, EventOpts additionalOpts = null, params KeyValuePair<string, string>[] additionalEventCaptureProps)
+        {
+
+            //addCSEventListener(type, elementID, csFuncID, additionalProps, options, abortKey)
+            var addlDict = additionalEventCaptureProps?.Length > 0 ?
+            Newtonsoft.Json.JsonConvert.SerializeObject( additionalEventCaptureProps.ToDictionary(x => x.Key, x => x.Value)) : null;
+            var abortKey = additionalOpts?.abortKey;
+            if (abortKey != null)
+                additionalOpts.abortKey = null;
+            var curId = window._RegisterBoundFunction(OnCalled: (str) => OnFired(Newtonsoft.Json.JsonConvert.DeserializeObject<DomEvent[]>(str)[0]), registerFunc: false);
+            //window.InvokeJavascriptMethod($"{ourJSClass}.addCSEventListener", eventType, domId, curId, addlDict, additionalOpts, abortKey);
+            window.ScriptEvaluateMethod<string>($"{ourJSClass}.addCSEventListener", eventType, domId, curId, addlDict, additionalOpts, abortKey);//not awiating but at least will be in background task exception
+        }
+        private static async void JavascriptFuncCallback(this Window window, int csFuncId, int jsCallId, string jsonOfArgs)
+        {
+            if (!csFuncIdToFired.TryGetValue(csFuncId, out var info))
+                throw new Exception($"The JS func callback handler was passed an invalid function id {csFuncId}"); ;
+            if (info.normFunc != null)
+            {
+                Window.UseSpecificDispatcher.InvokeWithVoid(() => info.normFunc(jsonOfArgs));
+                return;
+            }
+            var res = await Window.UseSpecificDispatcher.InvokeWithReturnType(() => info.taskFunc(jsonOfArgs));
+
+            await window.ScriptEvaluateMethod<string>($"{ourJSClass}.setCSFunctionResult", jsCallId, res);//we don't use invoke so we can get the error
+            //window.InvokeJavascriptMethod("setCSFunctionResult", jsCallId, res);
+
+        }
+        private const string ourJSClass = $"window.WebUINet";
+        public static void SetDebug(this Window window, bool debugging = true)
+        {
+            var jsDebug = debugging ? "true" : "false";
+            window.InvokeJavaScript($@"{ourJSClass}.DEBUG_MODE={jsDebug};
+window.webui.setLogging({jsDebug});
+");
+        }
+        public static void RegisterBoundFunction(this Window window, String RegisteredName, Func<string, Task<string>> OnCalled) => window._RegisterBoundFunction(RegisteredName, OnCalledTask: OnCalled);
+        public static void RegisterBoundFunction(this Window window, String RegisteredName, Action<string> OnCalled) => window._RegisterBoundFunction(RegisteredName, OnCalled);
+
+        private static int _RegisterBoundFunction(this Window window, String RegisteredName = null, Action<string> OnCalled = null, Func<string, Task<string>> OnCalledTask = null, bool registerFunc = true)
+        {
+            var curId = Interlocked.Increment(ref curFuncId);
+            csFuncIdToFired[curId] = new RegisteredFunc { taskFunc = OnCalledTask, normFunc = OnCalled };
+            if (registerFunc)
+            {
+                //we don't use invoke so we can get the error
+                window.ScriptEvaluateMethod<string>($"{ourJSClass}.addCSFunction", curId, RegisteredName, OnCalledTask != null); //not awaiting but exception will at least show in logs just no ST
+                //window.InvokeJavascriptMethod("WebUINet.addCSFunction", curId, RegisteredName, OnCalledTask != null);
+            }
+            if (curId == startId + 1)
+            {
+                window.RegisterEventHandler(RawFuncCallback, "webuiNet_Callback");
+            }
+            return curId;
+        }
+        public static void InitOurBridge(this Window window)
+        {
+            OurJSBytes = Encoding.UTF8.GetBytes(File.ReadAllText("webui_net.js"));
+            window.SetFileHandler((path) => path == "/webui_net.js" ? OurJSBytes : null);
+        }
+        private static byte[] OurJSBytes;
+        private static object RawFuncCallback(WebUI.Events.Event evt, string element, ulong handlerId)
+        {
+            evt.Window.JavascriptFuncCallback((int)evt.GetNumber(0), (int)evt.GetNumber(1), evt.GetString(2));
+            return null;
+        }
+
+        private class RegisteredFunc
+        {
+            public Func<string, Task<string>> taskFunc;
+            public Action<string> normFunc;
+        }
+        private static ConcurrentDictionary<int, RegisteredFunc> csFuncIdToFired = new();
+    }
+}

--- a/src/WebUI.NET/webui_net.js
+++ b/src/WebUI.NET/webui_net.js
@@ -1,0 +1,106 @@
+﻿
+{
+    class WebUINet {
+        static DEBUG_MODE = false;
+        // calls a CS function but does not return any result
+        static fireCSFunction = (csFuncId, ...args) => this.#_callFireCSFunction(csFuncId, false, args);
+        // calls a CS function and returns a promise that will resolve with the result
+        static callCSFunction = (csFuncId, ...args) => this.#_callFireCSFunction(csFuncId, true, args);
+        static #curCallNumber = 1234;
+        static #jsCallIdToPromise = new Map();
+        static #completedPromise = Promise.resolve();
+        static #_callFireCSFunction(csFuncId, needsReturn, ...args) {
+            const callId = this.#curCallNumber++;
+            if (this.DEBUG_MODE)
+                console.log(`executing js call: ${callId} a cs function: ${csFuncId} with args`, args);
+            webui.call("webuiNet_Callback", csFuncId, callId, JSON.stringify(...args));//webui has a 16 arg max limit so we will just stringify args and deserialize in CS
+            if (!needsReturn)
+                return this.#completedPromise; //not sure if we should do this or return undefined
+            let promise = new Promise((resolv) => this.#jsCallIdToPromise.set(callId, resolv));
+
+            return promise;
+        }
+
+        /// Options are standard options like capture, once, passive, abortKey is for a mantained internal db of AbortHandlers
+        static addCSEventListener(type, elementID, csFuncId, additionalProps, options, abortKey) {
+            if (this.DEBUG_MODE)
+                console.log(`addCSEventListener on element: ${elementID} for type: ${type}`);
+            let abortController = undefined;
+            if (abortKey) {
+                abortController = this.#abortKeyToHandlerMap.get(abortKey);
+                if (abortController == undefined) {
+                    abortController = new AbortController();
+                    this.#abortKeyToHandlerMap.set(abortKey, abortController);
+                }
+            }
+            let elem = document.getElementById(elementID);
+            if (!elem) {
+                if (elementID == "window")
+                    elem = window;
+                else if (elementID == "document")
+                    elem = document;
+                else {
+                    if (this.DEBUG_MODE)
+                        console.warn(`cannot find the element to add listener to of id: ${elementID}`);
+                    return;
+                }
+            }
+            let opts = { passive: true, signal: abortController };
+            Object.assign(opts, options);
+            if (additionalProps)
+                additionalProps = JSON.parse(additionalProps);
+            elem.addEventListener(type, new InternalEventRecord(csFuncId, additionalProps), opts);
+        }
+        static #abortKeyToHandlerMap = new Map();
+        static setCSFunctionResult(jsCallId, result) {
+            if (this.DEBUG_MODE)
+                console.log(`Setting cs result on jsCall: ${jsCallId} to: ${result}`);
+            const promise = this.#jsCallIdToPromise.get(jsCallId);
+            if (!promise)
+                return;
+            promise(result);
+        }
+        static addCSFunction(csFuncId, registeredName, hasResult) {
+            window[registeredName] = hasResult ? this.callCSFunction.bind(null, csFuncId) : this.fireCSFunction.bind(null, csFuncId);
+        }
+    }
+    class SerializableMap extends Map {
+        toJSON = () => Object.fromEntries(this);
+    }
+    class InternalEventRecord {
+        constructor(csFuncId, captureProps) {
+            this.csFuncId = csFuncId;
+            if (captureProps && typeof captureProps[Symbol.iterator] !== 'function')//this is a similar call to what map does
+                captureProps = Object.entries(captureProps);
+            this.captureProps = captureProps ? new Map(captureProps) : undefined;
+        }
+        csFuncId;
+        captureProps; //map to the additional properties to capture
+        static #getEventVal = (obj, path) => path.split('.').reduce((a, v) => (a ? a[v] : undefined), obj);
+
+        /**  @param {Event} evt */
+        handleEvent(evt) {
+            if (WebUINet.DEBUG_MODE)
+                console.log("Event listener callback got event: ", evt);
+
+            const eventInfo = new EventInfo();
+            eventInfo.currentTargetId = evt.currentTarget?.id;
+            eventInfo.originalTargetId = evt.target?.id;
+            eventInfo.timestamp = performance.timing.navigationStart + evt.timeStamp;
+            eventInfo.type = evt.type;
+            if (this.captureProps) {
+                eventInfo.additionalProps = new SerializableMap();
+                this.captureProps.forEach((val, key) => eventInfo.additionalProps.set(key, InternalEventRecord.#getEventVal(evt, val)));
+            }
+            WebUINet.fireCSFunction(this.csFuncId, eventInfo);
+        }
+    }
+    class EventInfo {
+        currentTargetId;
+        originalTargetId;
+        timestamp;
+        type;
+        additionalProps; //map of additional property values requested
+    }
+    window.WebUINet = WebUINet;
+}


### PR DESCRIPTION
Thanks for putting this together, WebUI looks interesting, hopefully this makes it friendlier to use.  Sorry for such a large set of changes but they kind of stack.


Added to match the normal API calls (not rename their function):
`public unsafe bool Script(string javaScript, uint timeout_secs, Span<Byte> buffer)`

Use Span for better memory efficiency and less allocation.
Use a memory pool for alleviating the need for the library consumer to handle buffers if they do not want to example:
`public async Task<T?> ScriptEvaluate<T>(string javascript, TimeSpan? timeout = null, bool? stringReturnsAreSerialized = null)`

That function also handles basic de-serialization to support various return types.

Moved this and future calls to use Task, even i the native library doesn't yet have async style calls we can still run on background threads and avoid UI wait.

Simplified event binding to bind click events:
`public void RegisterOnClick(Action<string> OnClick, String domId)`


Added direct method binding with:
`public void RegisterBoundFunction(LambdaExpression methodExpression, String OverrideRegisteredName = null, object OverrideInstance = null)`
This is a heavier function.  It allows you to bind any static or instance method into the Javascript namespace (at least it should, I don't get why the interface bind calls only are accessible via the "webui.call" functionality).  If this isn't fixed in the base library can work around just be creating our own JS alias.  It automatically will attempt to convert all args to the correct format, and handles missing args properly.  It supports binding an async function and will properly wait for you to return.   Note this does result in an ugly .Wait() call in the code, but as webui doesn't have any deferrals yet for return values I don't think there is another great option.  We could design all callbacks to run on a dedicated BG thread potentially if needed.

It takes Lambdas to allow for a very easy way to specify both the method and instance without having to use reflection as the caller.

Added calling javascript methods passing the args separately.  I noticed there is the raw function but I didn't dive into exactly how all the raw data would have to be presented.  This internally converts the call to a string, but it does it fairly robustly.  That code is 100% not mine, just the great work of @amaitland from https://github.com/cefsharp/CefSharp  the license is on the helper class page.  If for some reason you want to rip that out you can throw away the class and rewrite the functions to do it another way (or just take a full string call again).

`public async Task<T?> ScriptEvaluateMethod<T>(string javascriptMethod, params object[] args)`
This also automatically serializes the JS responses and can deserialize them on the c# side allow for complex arbitrary types to be passed.  On the c# side my example uses a static class definition but if you just do `ScriptEvaluateMethods<JObject>` you can walk the JS like normal.


I'd suggest seeing what is required to get listed on the official site for the c# package.  Looking at the other language libraries I think these changes make it one of the most advanced wrappers / friendly options available.   I would try to stick to official function naming for the common calls but then as you add additional user helpers you can use different naming that seems more natural.  This allows easy porting between WebUI languages.

Assume calls succeed throw exceptions if they don't.


Added a WPF demo project showing these features off.   Note the `WebUI.Window.UseSpecificDispatcher` is a bit clunky.  Could be done automatically when running with UI (and far easier if we can just assume we can access Application.Current.Dispatcher as we can use the invoke methods there and store the dispatcher in the constructor.

Hopefully these building block wrappers and tools can increase performance and make it easier for people to use the library.   I love the low overhead idea of WebUI.  While the API is also very basic because of it, hopefully this can show how rich experiences can be done with just wrapping those basic calls.  

I would suggest using project references rather for WebUI .NET lib rather than the nuget style you were doing for examples. Will make debugging and editing code much faster.


Future considerations:

Using a JS Proxy class one could bind entire C# classes into the javascript namespace with decent ease.  The proxy class would just change any calls to a middleman script (ie say webui.call("proxy_helper",bound_class_name,bound_func_name,args...)).  That C# function would just use reflection to find the function on the class and convert the args as I currently do.


Could easily add binder for any HTML eventListener with just some wrapped JS to be able to bind to.  Given the idea of this being used as a generic UI interface having only a 'click' handler is a bit silly.


Good luck, hope you continue to maintain this!